### PR TITLE
Include Cargo.lock in repo for reproducible builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /target
 **/*.rs.bk
-Cargo.lock
 bin/
 pkg/
 wasm-pack.log


### PR DESCRIPTION
It's good practice to include lockfiles in source control so that everyone gets the exact same dependencies.