### PR TITLE
Bump wasm-bindgen version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 cfg-if = "0.1.2"
-wasm-bindgen = "=0.2.65"
+wasm-bindgen = "=0.2.68"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires


### PR DESCRIPTION
0.2.65 will fail to install with error:
`wasm-bindgen v0.2.68` has no binaries
Update to newest version 0.2.68 fixes the issue