### PR TITLE
chore: update wasm-bindgen, add placeholder to wrangler.toml template

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 cfg-if = "0.1.2"
-wasm-bindgen = "=0.2.65"
+wasm-bindgen = "=0.2.73"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
-name = "rust"
+name = "{{project-name}}"
 type = "rust"
 
 account_id = ""


### PR DESCRIPTION
the pinned version of `wasm-bindgen` is incompatible with the resolved version of `console_error_panic_hook`, which itself depends on a different version of `wasm-bindgen`. this PR restores their compatibility. 