### PR TITLE
Add getrandom dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,10 @@ console_error_panic_hook = { version = "0.1.1", optional = true }
 # allocator, however.
 wee_alloc = { version = "0.4.2", optional = true }
 
+# We need this import with the "js" feature enabled for reasons explained
+# here: https://docs.rs/getrandom/#webassembly-support
+getrandom = { version = "0.2.3", features = ["js"] }
+
 [profile.release]
 # Tell `rustc` to optimize for small code size.
 opt-level = "s"


### PR DESCRIPTION
I'm not sure how it is for others, but for me the template doesn't work without this import. Here's the error I get otherwise when I run `wrangler build` (or `wrangler dev`):

```
error: the wasm32-unknown-unknown target is not supported by default, you may need to enable the "js" feature. For more information see: https://docs.rs/getrandom/#webassembly-support
   --> /REDACTED/.cargo/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.3/src/lib.rs:219:9
    |
219 | /         compile_error!("the wasm32-unknown-unknown target is not supported by \
220 | |                         default, you may need to enable the \"js\" feature. \
221 | |                         For more information see: \
222 | |                         https://docs.rs/getrandom/#webassembly-support");
    | |_________________________________________________________________________^

error[E0433]: failed to resolve: use of undeclared crate or module `imp`
   --> /REDACTED/.cargo/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.3/src/lib.rs:246:5
    |
246 |     imp::getrandom_inner(dest)
    |     ^^^ use of undeclared crate or module `imp`
```

This is on macOS with the `wasm32-unknown-unknown` target installed.