### PR TITLE
Change wrangler project type to "rust"

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,5 @@
 name = "{{project-name}}"
-type = "javascript"
+type = "rust"
 workers_dev = true
 compatibility_date = "2021-08-27" # required
 compatibility_flags = [ "formdata_parser_supports_files" ] # required


### PR DESCRIPTION
If you try "wrangler dev" on a project generated from this template, it will complain about no package.json because it things it's a javascript project.