### PR TITLE
Fix Compat Flag issue #29

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,7 +2,6 @@ name = "{{project-name}}"
 type = "javascript"
 workers_dev = true
 compatibility_date = "2021-08-27" # required
-compatibility_flags = [ "formdata_parser_supports_files" ] # required
 
 [vars]
 WORKERS_RS_VERSION = "0.0.6"


### PR DESCRIPTION
As of the 3-11-2021 the compatability flag "formdata_parser_supports_files" has become the default and the wrangler dev command will fail with the error described in issue #29.