### PR TITLE
chore: enable Miniflare `proxy_primitive_instanceof` option

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -18,5 +18,8 @@ main   = "./shim.mjs"
 globs = ["**/*.wasm"]
 type  = "CompiledWasm"
 
+[miniflare]
+proxy_primitive_instanceof = true
+
 # read more about configuring your Worker via wrangler.toml at:
 # https://developers.cloudflare.com/workers/cli-wrangler/configuration


### PR DESCRIPTION
Hey! 👋 This PR enables Miniflare's primitive class `instanceof` proxying, so `instanceof` checks suceed for objects created both inside (user code) and outside (runtime APIs) the Miniflare sandbox. This ensures code generated by `wasm-bindgen` like `value instanceof Object` for dynamic type checking will work as expected.

This behaviour used to be the default, but it was [causing](https://github.com/cloudflare/miniflare/issues/109) [too](https://github.com/cloudflare/miniflare/issues/137) [many](https://github.com/cloudflare/miniflare/issues/141) [issues](https://github.com/cloudflare/wrangler2/issues/91) with JavaScript projects, so it's now behind a flag as of the latest release. This flag will be ignored by Wrangler or old versions of Miniflare.

See https://v2.miniflare.dev/core/web-assembly#instanceof-checks and https://github.com/cloudflare/miniflare/blob/720794accee7582b01e849182244a65ce60c9d60/packages/core/src/plugins/core.ts#L487-L555 for more details on why this option is needed.