### PR TITLE
Add missing context argument to main function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ fn log_request(req: &Request) {
 }
 
 #[event(fetch)]
-pub async fn main(req: Request, env: Env) -> Result<Response> {
+pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Response> {
     log_request(&req);
 
     // Optionally, get more helpful error messages written to the console in the case of a panic.


### PR DESCRIPTION
The file `src/lib.rs` fails to compile due to a missing argument in the `main` function. This PR adds the missing context argument.


```sh
% wrangler generate --type=rust project_name
% cd project_name
% wrangler build

 Running cargo install -q worker-build && worker-build --release
  ...
error[E0061]: this function takes 2 arguments but 3 arguments were supplied
  --> src/lib.rs:17:14
   |
16 | #[event(fetch)]
   | ---------------
   | |
   | supplied 3 arguments
17 | pub async fn main(req: Request, env: Env) -> Result<Response> {
   |              ^^^^ expected 2 arguments
   |
note: function defined here
  --> src/lib.rs:17:14
   |
17 | pub async fn main(req: Request, env: Env) -> Result<Response> {
   |              ^^^^---------------

For more information about this error, try `rustc --explain E0061`.
Error: Compiling your crate to WebAssembly failed
Caused by: failed to execute `cargo build`: exited with exit status: 101
  full command: "cargo" "build" "--lib" "--release" "--target" "wasm32-unknown-unknown"
Error: wasm-pack exited with status exit status: 1
Error: Build failed! Status Code: 1
```
