### PR TITLE
Update wrangler.toml for Wrangler 2

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,22 +1,13 @@
 name = "{{project-name}}"
-type = "javascript"
 workers_dev = true
-compatibility_date = "2022-01-20"
+compatibility_date = "2022-05-15"
+main = "build/worker/shim.mjs"
 
 [vars]
 WORKERS_RS_VERSION = "0.0.9"
 
 [build]
 command = "cargo install -q worker-build && worker-build --release" # required
-
-[build.upload]
-dir = "build/worker"
-format = "modules"
-main = "./shim.mjs"
-
-[[build.upload.rules]]
-globs = ["**/*.wasm"]
-type = "CompiledWasm"
 
 # read more about configuring your Worker via wrangler.toml at:
 # https://developers.cloudflare.com/workers/cli-wrangler/configuration


### PR DESCRIPTION
Wrangler 2 automatically detects the type and rule and `build.upload` field isn't needed anymore.