### PR TITLE
chore: add `wasm-bindgen = "0.2"`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ default = ["console_error_panic_hook"]
 cfg-if = "0.1.2"
 worker = "0.0.9"
 serde_json = "1.0.67"
+wasm-bindgen = "0.2"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires


### PR DESCRIPTION
This is a missing piece from the following tutorial: https://developers.cloudflare.com/workers/tutorials/hello-world-rust/#publish