### PR TITLE
Update to latest versions of worker and cfg-if

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-cfg-if = "0.1.2"
-worker = "0.0.9"
+cfg-if = "1.0.0"
+worker = "0.0.21"
 serde_json = "1.0.67"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by


### PR DESCRIPTION
I was working with [this tutorial](https://developers.cloudflare.com/workers/tutorials/hello-world-rust/) and noticed a `[ERROR] Could not resolve "./index_bg.wasm"` error.

Found [this issue](https://github.com/cloudflare/workers-rs/issues/310) and realized the template has outdated dependencies.